### PR TITLE
feat: Add SD card mount and directory structure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,123 @@
 #include <Arduino.h>
 #include <M5GFX.h>
+#include <SD.h>
+#include <SPI.h>
 #include <LittleFS.h>
 #include <I2C_BM8563.h>
 
+// ============================================
+// Hardware Configuration
+// ============================================
 static M5GFX display;
 I2C_BM8563 rtc(I2C_BM8563_DEFAULT_ADDRESS, Wire);
 
+// M5Paper S3 SD Card pins
+#define SD_CS   4
+#define SD_SCK  36
+#define SD_MISO 35
+#define SD_MOSI 37
+
+// ============================================
+// Constants
+// ============================================
+const int SCREEN_WIDTH = 960;
+const int SCREEN_HEIGHT = 540;
+const int TAB_BAR_HEIGHT = 70;
+const int CONTENT_HEIGHT = SCREEN_HEIGHT - TAB_BAR_HEIGHT;
+
+const int PAD_X = 30;
+const int PAD_Y = 30;
+const int LINE_SPACING = 16;
+
+// SD Card directories
+const char* DIR_BOOKS = "/books";
+const char* DIR_DICT = "/dict";
+const char* DIR_FONTS = "/fonts";
+const char* DIR_USERDATA = "/userdata";
+
+// ============================================
+// State
+// ============================================
+bool sdCardMounted = false;
 std::vector<String> sentences;
 String todayTitle = "";
 String todayAuthor = "";
 String todayDate = "";
 int currentPage = -1;
 
-const int PAD_X = 30;
-const int PAD_Y = 30;
-const int LINE_SPACING = 16;
+// ============================================
+// SD Card Functions
+// ============================================
+bool initSDCard() {
+    SPI.begin(SD_SCK, SD_MISO, SD_MOSI, SD_CS);
 
+    if (!SD.begin(SD_CS, SPI, 25000000)) {
+        Serial.println("SD Card mount failed");
+        return false;
+    }
+
+    uint8_t cardType = SD.cardType();
+    if (cardType == CARD_NONE) {
+        Serial.println("No SD card attached");
+        return false;
+    }
+
+    Serial.print("SD Card Type: ");
+    switch (cardType) {
+        case CARD_MMC:  Serial.println("MMC"); break;
+        case CARD_SD:   Serial.println("SDSC"); break;
+        case CARD_SDHC: Serial.println("SDHC"); break;
+        default:        Serial.println("UNKNOWN"); break;
+    }
+
+    uint64_t cardSize = SD.cardSize() / (1024 * 1024);
+    Serial.printf("SD Card Size: %lluMB\n", cardSize);
+
+    return true;
+}
+
+bool ensureDirectories() {
+    const char* dirs[] = {DIR_BOOKS, DIR_DICT, DIR_FONTS, DIR_USERDATA};
+
+    for (const char* dir : dirs) {
+        if (!SD.exists(dir)) {
+            if (!SD.mkdir(dir)) {
+                Serial.printf("Failed to create directory: %s\n", dir);
+                return false;
+            }
+            Serial.printf("Created directory: %s\n", dir);
+        }
+    }
+    return true;
+}
+
+void showSDCardError(const char* message) {
+    display.fillScreen(TFT_WHITE);
+    display.setTextColor(TFT_BLACK);
+
+    int centerY = CONTENT_HEIGHT / 2;
+
+    display.setCursor(PAD_X, centerY - 40);
+    display.setTextSize(1.5);
+    display.println("SD Card Error");
+
+    display.setCursor(PAD_X, centerY + 20);
+    display.setTextSize(1.0);
+    display.println(message);
+
+    display.setCursor(PAD_X, centerY + 60);
+    display.println("Please insert SD card and restart.");
+
+    display.display();
+}
+
+uint64_t getSDCardFreeSpace() {
+    return SD.totalBytes() - SD.usedBytes();
+}
+
+// ============================================
+// Content Loading (Temporary - will be replaced with epub)
+// ============================================
 bool loadTodaySentences() {
     Wire.begin(41, 42);
     rtc.begin();
@@ -27,10 +129,21 @@ bool loadTodaySentences() {
     sprintf(target, "#%02d%02d", date.month, date.date);
     todayDate = String(date.month) + "月" + String(date.date) + "日";
 
-    File f = LittleFS.open("/365.txt", "r");
+    // Try SD card first, then LittleFS as fallback
+    File f;
+    String filePath = String(DIR_BOOKS) + "/365.txt";
+
+    if (SD.exists(filePath.c_str())) {
+        f = SD.open(filePath.c_str(), FILE_READ);
+    } else if (LittleFS.exists("/365.txt")) {
+        f = LittleFS.open("/365.txt", "r");
+    }
+
     if (!f) return false;
 
     bool found = false;
+    sentences.clear();
+
     while (f.available()) {
         String line = f.readStringUntil('\n');
         line.trim();
@@ -42,8 +155,10 @@ bool loadTodaySentences() {
         if (!found) continue;
         if (line.startsWith("TITLE:")) {
             todayTitle = line.substring(6);
+            todayTitle.trim();
         } else if (line.startsWith("AUTHOR:")) {
             todayAuthor = line.substring(7);
+            todayAuthor.trim();
         } else if (line.length() > 0) {
             sentences.push_back(line);
         }
@@ -52,6 +167,9 @@ bool loadTodaySentences() {
     return sentences.size() > 0;
 }
 
+// ============================================
+// Display Functions
+// ============================================
 int printWrapped(const String& text, int x, int y, int maxW) {
     int fontH = display.fontHeight();
     int bytePos = 0;
@@ -109,7 +227,7 @@ void showTitlePage() {
     display.println(todayAuthor);
 
     int totalPages = sentences.size() + 1;
-    display.setCursor(display.width() - 120, display.height() - PAD_Y);
+    display.setCursor(display.width() - 120, CONTENT_HEIGHT - PAD_Y);
     display.printf("1 / %d", totalPages);
     display.display();
 }
@@ -123,33 +241,67 @@ void showPage(int idx) {
     int totalPages = sentences.size() + 1;
     char info[20];
     sprintf(info, "%d / %d", idx + 2, totalPages);
-    display.setCursor(display.width() - 120, display.height() - PAD_Y);
+    display.setCursor(display.width() - 120, CONTENT_HEIGHT - PAD_Y);
     display.println(info);
     display.display();
 }
 
+// ============================================
+// Setup & Loop
+// ============================================
 void setup() {
+    Serial.begin(115200);
+    Serial.println("Papers3 JP Learner Starting...");
+
+    // Initialize display
     display.begin();
     display.waitDisplay();
-    display.setRotation(1);
+    display.setRotation(1);  // Landscape mode
     display.setEpdMode(epd_mode_t::epd_text);
     display.setTextColor(TFT_BLACK);
     display.setFont(&fonts::efontJA_24);
     display.setTextSize(1.4);
 
-    LittleFS.begin();
+    // Initialize LittleFS (for config and default font)
+    if (!LittleFS.begin()) {
+        Serial.println("LittleFS mount failed");
+    }
 
+    // Initialize SD Card
+    sdCardMounted = initSDCard();
+
+    if (!sdCardMounted) {
+        showSDCardError("SD card not detected.");
+        return;
+    }
+
+    // Ensure directory structure
+    if (!ensureDirectories()) {
+        showSDCardError("Failed to create directories.");
+        return;
+    }
+
+    Serial.printf("SD Card Free Space: %llu MB\n", getSDCardFreeSpace() / (1024 * 1024));
+
+    // Load content
     if (loadTodaySentences()) {
         showTitlePage();
     } else {
         display.fillScreen(TFT_WHITE);
         display.setCursor(PAD_X, PAD_Y);
         display.println("No data for today");
+        display.setCursor(PAD_X, PAD_Y + 40);
+        display.println("Place 365.txt in /books/ on SD card");
         display.display();
     }
 }
 
 void loop() {
+    if (!sdCardMounted) {
+        delay(1000);
+        return;
+    }
+
     lgfx::touch_point_t tp;
     if (display.getTouch(&tp, 1)) {
         delay(300);


### PR DESCRIPTION
## Summary
- SD 카드 마운트 및 초기화 구현
- 필수 디렉토리 구조 자동 생성 (/books, /dict, /fonts, /userdata)
- SD 카드 에러 핸들링 및 화면 표시
- 화면 레이아웃 상수 정의 (960x540, 탭 바 영역)

## Changes
- `initSDCard()`: M5Paper S3 SPI 핀으로 SD 카드 초기화
- `ensureDirectories()`: 필수 디렉토리 존재 확인/생성
- `showSDCardError()`: SD 카드 에러 메시지 표시
- `getSDCardFreeSpace()`: 남은 용량 확인
- SD 카드 우선, LittleFS 폴백 지원

## Test Plan
- [ ] SD 카드 삽입 시 정상 마운트 확인
- [ ] SD 카드 없을 때 에러 화면 표시 확인
- [ ] 디렉토리 자동 생성 확인
- [ ] 기존 365.txt 로드 기능 동작 확인

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)